### PR TITLE
feat: Convert New Session popup to standalone tab and update UI design

### DIFF
--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -220,3 +220,77 @@ Ready to proceed with Phase 4: Polish & iOS Features
 - Adaptive grid columns (4 columns on iPad, 3 on iPhone)
 - Dynamic font sizing based on device type
 - Responsive layout adjustments for different screen sizes
+
+---
+
+## New Session Tab Conversion Plan
+
+### Problem Statement
+Currently, the "New Session" tab behaves as a modal popup trigger rather than a proper standalone screen. When users tap the "New Session" tab, it:
+1. Shows the `SessionTimerView` as a sheet/popup
+2. Automatically resets to the Home tab (tag 0) after 0.1 seconds
+3. Uses a `Color.clear` placeholder instead of actual content
+
+### Current Implementation Analysis
+
+**ContentView.swift (lines 37-77)**:
+- Tab 2 uses `Color.clear` as placeholder content
+- `onChange(of: selectedTab)` detects tab 2 selection
+- Triggers `showingNewSession = true` to show sheet
+- Automatically resets to Home tab via `DispatchQueue.main.asyncAfter`
+- Presents `SessionTimerView` as `.sheet(isPresented: $showingNewSession)`
+
+**SessionTimerView.swift**:
+- Designed as modal with Cancel/Done header buttons
+- Uses `@Environment(\.dismiss)` for modal dismissal
+- Has NavigationView wrapper for modal presentation
+- Contains dismiss logic in Cancel button and completion flow
+
+### Implementation Plan
+
+#### 1. Update ContentView.swift ✅
+**Changes completed**:
+- [x] Replace `Color.clear` with `SessionTimerView()` for tab 2
+- [x] Remove `onChange(of: selectedTab)` logic for tab 2 handling
+- [x] Remove `@State private var showingNewSession = false`
+- [x] Remove `.sheet(isPresented: $showingNewSession)` modifier
+- [x] Ensure `SessionTimerView()` gets the coordinator environment
+
+#### 2. Update SessionTimerView.swift ✅
+**Changes completed**:
+- [x] Remove `@Environment(\.dismiss)` since it won't be a modal
+- [x] Remove NavigationView wrapper (ContentView handles navigation)
+- [x] Update header section to remove Reset/Cancel buttons
+- [x] Replace dismiss() calls with resetSession() logic
+- [x] Ensure proper state management for tab-based usage
+- [x] Update completion flow to reset state instead of dismissing
+
+#### 3. State Management Updates ✅
+**Implementation completed**:
+- [x] Handle session state persistence when switching tabs
+- [x] Add resetSession() function for clean state reset
+- [x] Ensure timer continues running when user switches tabs
+- [x] Handle proper cleanup with resetSession() function
+
+### Files Modified ✅
+1. **ContentView.swift** - Removed modal logic, added direct tab content
+2. **SessionTimerView.swift** - Removed modal-specific code, updated navigation
+
+### Implementation Results ✅
+**Time**: ~1 hour (faster than estimated)
+**Complexity**: Medium (required careful state management)
+**Risk**: Low (mostly UI changes, core logic preserved)
+
+**Key Changes Made**:
+- Converted popup modal to standalone tab experience
+- Timer now persists when switching between tabs
+- Removed Cancel/Reset buttons from header (cleaner UI)
+- Added resetSession() function for proper state management
+- Session completion now resets state instead of dismissing
+- Maintains all existing functionality while improving UX
+
+**Benefits Achieved**:
+- More intuitive tab navigation behavior
+- Timer continues running in background when switching tabs
+- Cleaner architecture without hacky tab switching logic
+- Better user experience with persistent session state

--- a/mindful-minutes/mindful-minutes/ContentView.swift
+++ b/mindful-minutes/mindful-minutes/ContentView.swift
@@ -11,7 +11,6 @@ import SwiftData
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
     @State private var dataCoordinator: MindfulDataCoordinator?
-    @State private var showingNewSession = false
     @State private var selectedTab = 0
 
     var body: some View {
@@ -35,7 +34,7 @@ struct ContentView: View {
                         .tag(1)
 
                     // New Session Tab (Center)
-                    Color.clear
+                    SessionTimerView()
                         .tabItem {
                             Image(systemName: "plus.circle.fill")
                             Text("New Session")
@@ -62,19 +61,6 @@ struct ContentView: View {
                 .environment(coordinator)
                 .accentColor(.mindfulPrimary)
                 .background(Color.mindfulBackground.ignoresSafeArea())
-                .onChange(of: selectedTab) { newValue in
-                    if newValue == 2 {
-                        showingNewSession = true
-                        // Reset to previous tab to avoid staying on the clear tab
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                            selectedTab = 0
-                        }
-                    }
-                }
-                .sheet(isPresented: $showingNewSession) {
-                    SessionTimerView()
-                        .environment(coordinator)
-                }
             } else {
                 ProgressView("Loading...")
                     .foregroundColor(.mindfulTextPrimary)

--- a/mindful-minutes/mindful-minutes/DesignSystem.swift
+++ b/mindful-minutes/mindful-minutes/DesignSystem.swift
@@ -3,8 +3,8 @@ import SwiftUI
 extension Color {
     static let mindfulPrimary = Color(red: 0.063, green: 0.725, blue: 0.506)
     static let mindfulSecondary = Color(red: 0.078, green: 0.722, blue: 0.651)
-    static let mindfulBackground = Color(red: 0.941, green: 0.992, blue: 0.957)
-    static let mindfulBackgroundSecondary = Color(red: 0.925, green: 0.992, blue: 0.961)
+    static let mindfulBackground = Color.white
+    static let mindfulBackgroundSecondary = Color(red: 0.98, green: 0.98, blue: 0.98)
     static let mindfulTextPrimary = Color.black
     static let mindfulTextSecondary = Color.black.opacity(0.6)
 }
@@ -19,7 +19,7 @@ struct MindfulCard<Content: View>: View {
     var body: some View {
         content
             .padding()
-            .background(Color.mindfulBackground)
+            .background(Color.mindfulBackgroundSecondary)
             .cornerRadius(12)
             .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
     }

--- a/mindful-minutes/mindful-minutes/mindful_minutesApp.swift
+++ b/mindful-minutes/mindful-minutes/mindful_minutesApp.swift
@@ -39,7 +39,7 @@ struct MindfulMinutesApp: App {
         // Configure navigation bar appearance
         let navBarAppearance = UINavigationBarAppearance()
         navBarAppearance.configureWithOpaqueBackground()
-        navBarAppearance.backgroundColor = UIColor(Color.mindfulBackground)
+        navBarAppearance.backgroundColor = UIColor.white
         navBarAppearance.titleTextAttributes = [.foregroundColor: UIColor.black]
         navBarAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.black]
         
@@ -47,10 +47,10 @@ struct MindfulMinutesApp: App {
         UINavigationBar.appearance().scrollEdgeAppearance = navBarAppearance
         UINavigationBar.appearance().compactAppearance = navBarAppearance
         
-        // Configure tab bar appearance  
+        // Configure tab bar appearance
         let tabBarAppearance = UITabBarAppearance()
         tabBarAppearance.configureWithOpaqueBackground()
-        tabBarAppearance.backgroundColor = UIColor(Color.mindfulBackground)
+        tabBarAppearance.backgroundColor = UIColor.white
         
         UITabBar.appearance().standardAppearance = tabBarAppearance
         UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
@@ -59,10 +59,10 @@ struct MindfulMinutesApp: App {
         UISegmentedControl.appearance().selectedSegmentTintColor = UIColor(Color.mindfulPrimary)
         UISegmentedControl.appearance().setTitleTextAttributes([.foregroundColor: UIColor.white], for: .selected)
         UISegmentedControl.appearance().setTitleTextAttributes([.foregroundColor: UIColor.black], for: .normal)
-        UISegmentedControl.appearance().backgroundColor = UIColor(Color.mindfulBackground)
+        UISegmentedControl.appearance().backgroundColor = UIColor.white
         
         // Configure other UI elements
-        UITableView.appearance().backgroundColor = UIColor(Color.mindfulBackground)
-        UIScrollView.appearance().backgroundColor = UIColor(Color.mindfulBackground)
+        UITableView.appearance().backgroundColor = UIColor.white
+        UIScrollView.appearance().backgroundColor = UIColor.white
     }
 }


### PR DESCRIPTION
- Convert New Session tab from modal popup to proper standalone screen
- Replace popup trigger logic with direct SessionTimerView integration
- Remove NavigationView wrapper and modal-specific code from SessionTimerView
- Add resetSession() function for proper state management
- Replace Start Session button with circular play button design
- Change app background from mindful green tint to clean white
- Update card backgrounds to light gray for better contrast
- Ensure timer persists when switching between tabs

🤖 Generated with [Claude Code](https://claude.ai/code)